### PR TITLE
FIX: (adoc-promote): headings get wrongfully turned into sub-type 2

### DIFF
--- a/adoc-mode-test.el
+++ b/adoc-mode-test.el
@@ -696,6 +696,14 @@ removed before TRANSFORM is evaluated.
 
 (ert-deftest adoctest-test-promote-title ()
   (adoctest-trans "= foo" "== foo" '(adoc-promote-title 1))
+  (adoctest-trans "= <foo>
+
+  bar"
+                  "== foo
+
+  bar"
+                  '(adoc-promote-title 1))
+  (adoctest-trans "= foo " "== foo" '(adoc-promote-title 1))
   (adoctest-trans "===== foo" "= foo" '(adoc-promote-title 1))
   (adoctest-trans "== foo" "==== foo" '(adoc-promote-title 2))
 

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -175,6 +175,7 @@
 
 (require 'markup-faces) ; https://github.com/sensorflo/markup-faces
 (require 'cl-lib)
+(eval-when-compile (require 'subr-x))
 (require 'tempo)
 
 (defconst adoc-mode-version "0.6.6"
@@ -2699,7 +2700,7 @@ trailing delimiter ('== my title ==').
          ((looking-at (adoc-re-one-line-title level))
           (setq type 1)
           (setq text (match-string 2))
-          (setq sub-type (if (< 0 (length (match-string 3))) 2 1))
+          (setq sub-type (if (< 0 (length (string-trim-right (match-string 3)))) 2 1))
           (setq found t))
          ;; WARNING: if you decide to replace adoc-re-two-line-title with a
          ;; method ensuring the correct length of the underline, be aware that


### PR DESCRIPTION
If the heading contains whitespace or a newline after the
heading title it gets turned into a sub-type 2 heading.

- add failing tests
- fix issue by throwing away whitespace in match group 3

---

In theory we could change the regex but a comment indicates that some other logic depends on the newline being matched, but I didn't investigate further:
https://github.com/toemacs/adoc-mode/blob/c0906ff95d2d8bb79a130f9325370607c826ffda/adoc-mode.el#L689-L691